### PR TITLE
Ensure element names are lowercased

### DIFF
--- a/lib/xpath/expression.rb
+++ b/lib/xpath/expression.rb
@@ -79,7 +79,7 @@ module XPath
 
     class Name < Unary
       def to_xpath(predicate=nil)
-        "name(#{@expression.to_xpath(predicate)})"
+        "translate(name(#{@expression.to_xpath(predicate)}), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"
       end
     end
 


### PR DESCRIPTION
When attempting to run the capybara test suite, I get failures on two examples for selenium. It seems to be because selenium returns node names ('name(.)') as uppercased strings -- unfortunately it also doesn't support the lower-case function. This may not be the most elegant solution (perhaps there should be a LowerCase expression), but without it I cannot get capybara's specs to pass.
