### PR TITLE
Failing spec for locating fields by labels containing single quotes

### DIFF
--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -54,6 +54,8 @@
   </button>
 
   <input type="schmoo" value="schmoo button" data="schmoo"/>
+  <label for="text-with-id">Label text <input type="text" id="text-with-id" data="id-text" value="monkey"/></label>
+  <label for="problem-text-with-id">Label text's got an apostrophe <input type="text" id="problem-text-with-id" data="id-problem-text" value="monkey"/></label>
 </p>
 
 <p>

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -124,14 +124,15 @@ describe XPath::HTML do
     end
 
     context "by parent label" do
-      it("finds inputs with text type")     {}
-      it("finds inputs with password type") {}
-      it("finds inputs with custom type")   {}
-      it("finds textareas")                 {}
-      it("finds select boxes")              {}
-      it("does not find submit buttons")    {}
-      it("does not find image buttons")     {}
-      it("does not find hidden fields")     {}
+      it("finds inputs with text type")                    { get('Label text').should == 'id-text' }
+      it("finds inputs where label has problem chars")     { get("Label text's got an apostrophe").should == 'id-problem-text' }
+      it("finds inputs with password type")                {}
+      it("finds inputs with custom type")                  {}
+      it("finds textareas")                                {}
+      it("finds select boxes")                             {}
+      it("does not find submit buttons")                   {}
+      it("does not find image buttons")                    {}
+      it("does not find hidden fields")                    {}
     end
 
     context "with :with option" do


### PR DESCRIPTION
This commit contains a tweak to the `form.html` fixture and a failing spec in `spec/html_spec.rb`, related to the issue jnicklas/xpath#6
