### PR TITLE
XPath::HTML.field specs & :disabled option

### DIFF
--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -31,6 +31,7 @@ module XPath
       xpath = locate_field(xpath, locator)
       xpath = xpath[attr(:checked)] if options[:checked]
       xpath = xpath[~attr(:checked)] if options[:unchecked]
+      xpath = xpath[attr(:disabled)] if options[:disabled]
       xpath = xpath[field_value(options[:with])] if options.has_key?(:with)
       xpath
     end

--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -87,6 +87,7 @@
   <label>Label for hidden
     <input type="hidden" id="hidden-with-id" name="hidden-with-name" data="id-hidden" />
   </label>
+  <input type="text" id="disabled-text" disabled="disabled" data="disabled"/>
 </p>
 
 <p>

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -157,6 +157,11 @@ describe XPath::HTML do
         it("finds checked fields")    { get("unchecked-checkbox").should == "unchecked" }
       end
     end
+    
+    context "with :disabled option" do
+      it("finds disabled fields")     { get("disabled-text", :disabled => true).should == "disabled" }
+      it("omits enabled fields")      { get("Label text", :disabled => true).should be_nil }
+    end
   end
 
   describe '#fillable_field' do


### PR DESCRIPTION
Hi,

I added some specs for XPath::HTML.field (they were already there but empty). I'm not sure I've followed exactly the testing style but I tried and hope so.

I also added a :disabled option to that method, as at least for me is useful.

I hope you like my changes. Thank you for your work in Capybara & friends!
## 

  Sergio
