### PR TITLE
Normalize HTML#table whitespace

### DIFF
--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -93,9 +93,9 @@ module XPath
     end
 
     def table_row(cells)
-      cell_conditions = child(:td, :th)[text.equals(cells.first)]
+      cell_conditions = child(:td, :th)[string.n.equals(cells.first)]
       cells.drop(1).each do |cell|
-        cell_conditions = cell_conditions.next_sibling(:td, :th)[text.equals(cell)]
+        cell_conditions = cell_conditions.next_sibling(:td, :th)[string.n.equals(cell)]
       end
       cell_conditions
     end

--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -77,3 +77,14 @@
     <optgroup label="Group B" data="optgroup-b"></optgroup>
   </select>
 </p>
+
+<p>
+  <table id="whitespaced-table" data="table-with-whitespace">
+    <tr>
+      <td data="cell-whitespaced">I have
+        <span>nested whitespace</span>
+      </td>
+      <td>I don't</td>
+    </tr>
+  </table>
+</p>

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -172,4 +172,10 @@ describe XPath::HTML do
 
     it("finds optgroups by label") { get('Group A').should == 'optgroup-a' }
   end
+
+  describe "#table" do
+    subject {:table}
+
+    it("finds cell content regardless of whitespace") {get('whitespaced-table', :rows => [["I have nested whitespace", "I don't"]]).should == 'table-with-whitespace'}
+  end
 end


### PR DESCRIPTION
As requested in http://groups.google.com/group/ruby-capybara/browse_thread/thread/2d7c9f920c8b693e I changed HTML#table to normalize the whitespace in the cell, and also made it use string instead of text so that nested text would be picked up as well. 

Steve
