### PR TITLE
Locate fields by their placeholder attribute

### DIFF
--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -102,7 +102,7 @@ module XPath
   protected
 
     def locate_field(xpath, locator)
-      locate_field = xpath[attr(:id).equals(locator) | attr(:name).equals(locator) | attr(:id).equals(anywhere(:label)[string.n.is(locator)].attr(:for))]
+      locate_field = xpath[attr(:id).equals(locator) | attr(:name).equals(locator) | attr(:id).equals(anywhere(:label)[string.n.is(locator)].attr(:for)) | attr(:placeholder).equals(locator)]
       locate_field += descendant(:label)[string.n.is(locator)].descendant(xpath)
     end
 

--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -56,6 +56,7 @@
 
   <input type="schmoo" value="schmoo button" data="schmoo"/>
   <label for="text-with-id">Label text <input type="text" id="text-with-id" data="id-text" value="monkey"/></label>
+  <input type="text" id="text-with-placeholder" data="placeholder-text" value="monkey" placeholder="Placeholder text"/>
   <label for="problem-text-with-id">Label text's got an apostrophe <input type="text" id="problem-text-with-id" data="id-problem-text" value="monkey"/></label>
 </p>
 

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -167,6 +167,9 @@ describe XPath::HTML do
       it("finds inputs with text type")                    { get('Label text').should == 'id-text' }
       it("finds inputs where label has problem chars")     { get("Label text's got an apostrophe").should == 'id-problem-text' }
     end
+    context "by placeholder" do
+      it("finds inputs with placeholder text")              { get('Placeholder text').should == 'placeholder-text' }
+    end
 
   end
 


### PR DESCRIPTION
This commit updates XPath::HTML.locate_field to look for fields by their placeholder attribute, in addition to their id, name or associated label.

The specification for the placeholder attribute (http://vurl.me/AEDP) does say that the purpose of the placeholder is to provide a short hint about the data to be entered. Based on this, the placeholder is intended to serve a different purpose than say, an associated label. As such, this commit might not be necessary.

However, I have noticed that particularly on mobile versions of web sites, the placeholder attribute is in practice used almost exclusively as a replacement for a label. This is probably to save space in the UI by not needing a label for each field. For this reason, I have found it very useful to locate fields by their placeholder attribute when test driving the UI for the mobile version of a site.
