### PR TITLE
Fix issue #22 (nested fieldsets with legends)

### DIFF
--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -24,7 +24,7 @@ module XPath
     end
 
     def fieldset(locator)
-      descendant(:fieldset)[attr(:id).equals(locator) | descendant(:legend)[string.n.is(locator)]]
+      descendant(:fieldset)[attr(:id).equals(locator) | child(:legend)[string.n.is(locator)]]
     end
 
     def field(locator, options={})

--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -77,6 +77,9 @@
   <fieldset data="fieldset-legend-span"><legend><span>Span Legend</span></legend></fieldset>
   <fieldset data="fieldset-fuzzy"><legend>Long legend yo</legend></fieldset>
   <fieldset data="fieldset-exact"><legend>Long legend</legend></fieldset>
+  <fieldset data="fieldset-outer"><legend>Outer legend</legend>
+    <fieldset data="fieldset-inner"><legend>Inner legend</legend></fieldset>
+  </fieldset>
 </p>
 
 <p>

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -100,6 +100,7 @@ describe XPath::HTML do
     it("finds fieldsets by legend child tags")   { get('Span Legend').should == 'fieldset-legend-span' }
     it("accepts approximate legends")            { get('Legend').should == 'fieldset-legend' }
     it("prefers exact legend")                   { all('Long legend').should == ['fieldset-exact', 'fieldset-fuzzy'] }
+    it("finds nested fieldsets by legend")       { get('Inner legend').should == 'fieldset-inner' }
   end
 
   describe '#field' do


### PR DESCRIPTION
This is a fix for issue #22 - by using `child` instead of `descendant` on the legend element, we get the correct `./` xpath selector instead of `.//`. Spec test included.
