### PR TITLE
Find fields by placeholder

### DIFF
--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -211,7 +211,7 @@ module XPath
   protected
 
     def locate_field(xpath, locator)
-      locate_field = xpath[attr(:id).equals(locator) | attr(:name).equals(locator) | attr(:id).equals(anywhere(:label)[string.n.is(locator)].attr(:for))]
+      locate_field = xpath[attr(:id).equals(locator) | attr(:name).equals(locator) | attr(:placeholder).equals(locator) | attr(:id).equals(anywhere(:label)[string.n.is(locator)].attr(:for))]
       locate_field += descendant(:label)[string.n.is(locator)].descendant(xpath)
     end
 

--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -125,6 +125,14 @@
   <input type="image" name="input-image-with-name" data="input-image-with-name-data"/>
   <input type="hidden" name="input-hidden-with-name" data="input-hidden-with-name-data"/>
 
+  <h4>With placeholder</h4>
+  <input name="input-with-placeholder" data="input-with-placeholder-data"/>
+  <input type="text" placeholder="input-text-with-placeholder" data="input-text-with-placeholder-data"/>
+  <input type="password" placeholder="input-password-with-placeholder" data="input-password-with-placeholder-data"/>
+  <input type="custom" placeholder="input-custom-with-placeholder" data="input-custom-with-placeholder-data"/>
+  <textarea placeholder="textarea-with-placeholder" data="textarea-with-placeholder-data"></textarea>
+  <input type="hidden" placeholder="input-hidden-with-placeholder" data="input-hidden-with-placeholder-data"/>
+
   <h4>With referenced label</h4>
   <label for="input-with-label">Input with label</label><input id="input-with-label" data="input-with-label-data"/>
   <label for="input-text-with-label">Input text with label</label><input type="text" id="input-text-with-label" data="input-text-with-label-data"/>

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -130,6 +130,15 @@ describe XPath::HTML do
       it("does not find hidden fields")     { get('input-hidden-with-name').should be_nil }
     end
 
+    context "by placeholder" do
+      it("finds inputs with no type")       { get('input-with-placeholder').should == 'input-with-placeholder-data' }
+      it("finds inputs with text type")     { get('input-text-with-placeholder').should == 'input-text-with-placeholder-data' }
+      it("finds inputs with password type") { get('input-password-with-placeholder').should == 'input-password-with-placeholder-data' }
+      it("finds inputs with custom type")   { get('input-custom-with-placeholder').should == 'input-custom-with-placeholder-data' }
+      it("finds textareas")                 { get('textarea-with-placeholder').should == 'textarea-with-placeholder-data' }
+      it("does not find hidden fields")     { get('input-hidden-with-placeholder').should be_nil }
+    end
+
     context "by referenced label" do
       it("finds inputs with no type")       { get('Input with label').should == 'input-with-label-data' }
       it("finds inputs with text type")     { get('Input text with label').should == 'input-text-with-label-data' }


### PR DESCRIPTION
We're using HTML5's placeholder attribute instead of external labels, and we still want Capybara to be able to find the fields by the placeholder text instead of having to use the field's id or label. I modified xpath to be able to do this.

Capybara will need a patch so that it reports "cannot fill in, no text field, text area or password field with id, name, _placeholder,_ or label" once this functionality is in xpath. I haven't taken a crack at that yet.

Thanks for all the great tools!
