### PR TITLE
HTML buttons with descendant images can be found by alt

### DIFF
--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -29,7 +29,7 @@ module XPath
     #
     def button(locator)
       button = descendant(:input)[attr(:type).one_of('submit', 'image', 'button')][attr(:id).equals(locator) | attr(:value).is(locator) | attr(:title).is(locator)]
-      button += descendant(:button)[attr(:id).equals(locator) | attr(:value).is(locator) | string.n.is(locator) | attr(:title).is(locator)]
+      button += descendant(:button)[attr(:id).equals(locator) | attr(:value).is(locator) | string.n.is(locator) | attr(:title).is(locator)  | descendant(:img)[attr(:alt).is(locator)]]
       button += descendant(:input)[attr(:type).equals('image')][attr(:alt).is(locator)]
     end
 

--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -57,6 +57,7 @@
   <button title="My btag title" data="title-btag">btag-with-title</button>
   <button title="Not Exact btag title" data="not-exact-title-btag">not exact title btag</button>
   <button title="Exact btag title" data="exact-title-btag">exact title btag</button>
+  <button data="btag-with-imgalt"><img alt="button-with-img"></button>
 
   <button data="btag-with-whitespace">    My
 

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -58,6 +58,7 @@ describe XPath::HTML do
       it("finds buttons by title")             { get('My button title').should == 'title-button' }
       it("finds buttons by approximate title") { get('button title').should == 'title-button' }
       it("prefers exact matches of title")     { all('Exact button title').should == ['exact-title-button', 'not-exact-title-button'] }
+      it("finds images by alt attribute")      { get('button-with-img').should == 'btag-with-imgalt' }
     end
 
     context "with image type" do


### PR DESCRIPTION
The following construct should now work:

```
<button><img alt="Submit" src="submit.png"></button>
```

It's a bit of a silly construct really, since `<input type="image">` exists, but it came up in a real application I was testing.
