### PR TITLE
Add support for xpath starts-with function

### DIFF
--- a/lib/xpath/dsl.rb
+++ b/lib/xpath/dsl.rb
@@ -33,6 +33,10 @@ module XPath
         Expression.new(:contains, current, expression)
       end
 
+      def starts_with(expression)
+        Expression.new(:starts_with, current, expression)
+      end
+
       def text
         Expression.new(:text, current)
       end

--- a/lib/xpath/renderer.rb
+++ b/lib/xpath/renderer.rb
@@ -123,9 +123,12 @@ module XPath
       "contains(#{current}, #{value})"
     end
 
+    def starts_with(current, value)
+      "starts-with(#{current}, #{value})"
+    end
+
     def and(one, two)
       "(#{one} and #{two})"
-
     end
 
     def or(one, two)

--- a/spec/xpath_spec.rb
+++ b/spec/xpath_spec.rb
@@ -125,6 +125,25 @@ describe XPath do
     end
   end
 
+  describe '#starts_with' do
+    it "should find nodes that begin with the given string" do
+      @results = xpath do |x|
+        x.descendant(:*).where(x.attr(:id).starts_with('foo'))
+      end
+      @results.size.should == 2
+      @results[0][:id].should == "foo"
+      @results[1][:id].should == "fooDiv"
+    end
+
+    it "should find nodes that contain the given expression" do
+      @results = xpath do |x|
+        expression = x.anywhere(:div).where(x.attr(:title) == 'fooDiv').attr(:id)
+        x.descendant(:div).where(x.attr(:title).starts_with(expression))
+      end
+      @results[0][:id].should == "foo"
+    end
+  end
+
   describe '#text' do
     it "should select a node's text" do
       @results = xpath { |x| x.descendant(:p).where(x.text == 'Bax') }


### PR DESCRIPTION
Added tests and support for the starts-with function of xpath, e.g:

```
    x.descendant(:*).where(x.attr(:id).starts_with('foo'))
```

I based the tests on the ones for contains, let me know if they're thorough enough.
