### PR TITLE
Multiple anywhere expressions

### DIFF
--- a/lib/xpath/dsl.rb
+++ b/lib/xpath/dsl.rb
@@ -29,8 +29,8 @@ module XPath
         Expression.new(:previous_sibling, current, expressions)
       end
 
-      def anywhere(expression)
-        Expression.new(:anywhere, expression)
+      def anywhere(*expressions)
+        Expression.new(:anywhere, expressions)
       end
 
       def attr(expression)

--- a/lib/xpath/renderer.rb
+++ b/lib/xpath/renderer.rb
@@ -113,8 +113,14 @@ module XPath
       expressions.join(' | ')
     end
 
-    def anywhere(tag_name)
-      "//#{tag_name}"
+    def anywhere(element_names)
+      if element_names.length == 1
+        "//#{element_names.first}"
+      elsif element_names.length > 1
+        "//*[#{element_names.map { |e| "self::#{e}" }.join(" | ")}]"
+      else
+        "//*"
+      end
     end
 
     def contains(current, value)

--- a/spec/xpath_spec.rb
+++ b/spec/xpath_spec.rb
@@ -1,3 +1,4 @@
+require 'debugger'
 require 'spec_helper'
 
 require 'nokogiri'
@@ -134,10 +135,12 @@ describe XPath do
         context=x.descendant(:div).where(x.attr(:id)=='woo')
         context.anywhere
       end
-      @results[3].text.should == 'Blah'
-      @results[7].text.should == 'A list'
-      @results[10].text.should == 'A list'
-      @results[12].text.should == 'Bax'
+      @results[0].name.should == 'html'
+      @results[1].name.should == 'body'
+      @results[5].text.should == 'Blah'
+      @results[9].text.should == 'A list'
+      @results[12].text.should == 'A list'
+      @results[14].text.should == 'Bax'
     end
     
   end


### PR DESCRIPTION
Adds support for passing multiple element names to anywhere (same as descendant allows).  This would be nice for cleaning up the form#params method in my PR adding form attribute support to capybara
