### PR TITLE
finds links without href

### DIFF
--- a/lib/xpath/html.rb
+++ b/lib/xpath/html.rb
@@ -10,7 +10,7 @@ module XPath
     #
     def link(locator)
       locator = locator.to_s
-      link = descendant(:a)[attr(:href)]
+      link = descendant(:a)
       link[attr(:id).equals(locator) | string.n.is(locator) | attr(:title).is(locator) | descendant(:img)[attr(:alt).is(locator)]]
     end
 

--- a/spec/fixtures/form.html
+++ b/spec/fixtures/form.html
@@ -18,6 +18,7 @@
   <a href="#has-children" data="link-children">
     An <em>emphatic</em> link with some children
   </a>
+  <a id="link-without-href" data="no-href">No href here</a>
 </p>
 
 <p>

--- a/spec/html_spec.rb
+++ b/spec/html_spec.rb
@@ -28,6 +28,7 @@ describe XPath::HTML do
     it("finds links by approximate title")                 { get('title').should == 'link-title' }
     it("finds links by image's alt attribute")             { get('Alt link').should == 'link-img' }
     it("finds links by image's approximate alt attribute") { get('Alt').should == 'link-img' }
+    it("finds links without href")                         { get('link-without-href').should == 'no-href' }
     it("does not find links without href attriutes")       { get('Wrong Link').should be_nil }
     it("casts to string")                                  { get(:'some-id').should == 'link-id' }
 


### PR DESCRIPTION
Added support to find links without `href`. Still works as expected with links with `href` but now also finds links without `href`.
