### PR TITLE
Clean up operator aliases

### DIFF
--- a/lib/xpath/dsl.rb
+++ b/lib/xpath/dsl.rb
@@ -56,7 +56,7 @@ module XPath
     def union(*expressions)
       Union.new(*[self, expressions].flatten)
     end
-    alias_method :+, :union
+    alias_method :|, :union
 
     def last
       function(:last)
@@ -88,19 +88,21 @@ module XPath
 
     alias_method :inverse, :not
     alias_method :~, :not
+    alias_method :!, :not
     alias_method :normalize, :normalize_space
     alias_method :n, :normalize_space
 
     OPERATORS = [
       [:equals, :"=", :==],
-      [:or, :or, :|],
-      [:and, :and, :&],
+      [:not_equals, :!=, :!=],
+      [:or, :or],
+      [:and, :and],
       [:lte, :<=, :<=],
       [:lt, :<, :<],
       [:gte, :>=, :>=],
       [:gt, :>, :>],
-      [:plus, :+],
-      [:minus, :-],
+      [:plus, :+, :+],
+      [:minus, :-, :-],
       [:multiply, :*, :*],
       [:divide, :div, :/],
       [:mod, :mod, :%],

--- a/spec/xpath_spec.rb
+++ b/spec/xpath_spec.rb
@@ -246,6 +246,10 @@ describe XPath do
     it "should be aliased as the unary tilde" do
       xpath { |x| x.descendant(:p).where(~x.attr(:id).equals('fooDiv')) }.first.text.should == 'Bax'
     end
+
+    it "should be aliased as the unary bang" do
+      xpath { |x| x.descendant(:p).where(!x.attr(:id).equals('fooDiv')) }.first.text.should == 'Bax'
+    end
   end
 
   describe '#equals' do
@@ -289,27 +293,12 @@ describe XPath do
       end
       @results[0][:title].should == "monkey"
     end
-
-    it "should be aliased as ampersand (&)" do
-      @results = xpath do |x|
-        x.descendant(:*).where(x.contains('Bax') & x.attr(:title).equals('monkey'))
-      end
-      @results[0][:title].should == "monkey"
-    end
   end
 
   describe '#or' do
     it "should find all nodes in either expression" do
       @results = xpath do |x|
         x.descendant(:*).where(x.attr(:id).equals('foo').or(x.attr(:id).equals('fooDiv')))
-      end
-      @results[0][:title].should == "fooDiv"
-      @results[1].text.should == "Blah"
-    end
-
-    it "should be aliased as pipe (|)" do
-      @results = xpath do |x|
-        x.descendant(:*).where(x.attr(:id).equals('foo') | x.attr(:id).equals('fooDiv'))
       end
       @results[0][:title].should == "fooDiv"
       @results[1].text.should == "Blah"
@@ -370,10 +359,10 @@ describe XPath do
       @results[0][:id].should == 'fooDiv'
     end
 
-    it "should be aliased as +" do
+    it "should be aliased as |" do
       @expr1 = XPath.generate { |x| x.descendant(:p) }
       @expr2 = XPath.generate { |x| x.descendant(:div) }
-      @collection = @expr1 + @expr2
+      @collection = @expr1 | @expr2
       @xpath1 = @collection.where(XPath.attr(:id) == 'foo').to_xpath
       @xpath2 = @collection.where(XPath.attr(:id) == 'fooDiv').to_xpath
       @results = doc.xpath(@xpath1)
@@ -445,7 +434,7 @@ describe XPath do
 
   describe "#plus" do
     it "adds stuff" do
-      @results = xpath { |x| x.descendant(:p)[XPath.position().plus(1) == 2] }
+      @results = xpath { |x| x.descendant(:p)[XPath.position() + 1 == 2] }
       @results[0][:id].should == "fooDiv"
       @results[1][:title].should == "gorilla"
     end
@@ -453,7 +442,7 @@ describe XPath do
 
   describe "#minus" do
     it "subtracts stuff" do
-      @results = xpath { |x| x.descendant(:p)[XPath.position().minus(1) == 0] }
+      @results = xpath { |x| x.descendant(:p)[XPath.position() - 1 == 0] }
       @results[0][:id].should == "fooDiv"
       @results[1][:title].should == "gorilla"
     end


### PR DESCRIPTION
Some of the aliases don’t conform to what the equivalent is in the XPath spec.

- `+` should be addition
- `|` should be union

Also removes the `&` alias for consistencies sake.

Also adds unary `!` as an alias for `inverse`