### PR TITLE
Make #where a no-op when passed nil

### DIFF
--- a/lib/xpath/renderer.rb
+++ b/lib/xpath/renderer.rb
@@ -55,7 +55,12 @@ module XPath
     end
 
     def where(on, condition)
-      "#{on}[#{condition}]"
+      condition = condition.to_s
+      if !condition.empty?
+        "#{on}[#{condition}]"
+      else
+        on.to_s
+      end
     end
 
     def attribute(current, name)

--- a/spec/xpath_spec.rb
+++ b/spec/xpath_spec.rb
@@ -247,6 +247,10 @@ describe XPath do
     it "should be aliased as []" do
       xpath { |x| x.descendant(:div)[:"@id = 'foo'"] }.first[:title].should eq "fooDiv"
     end
+
+    it "should be a no-op when nil condition is passed" do
+      XPath.descendant(:div).where(nil).to_s.should eq ".//div"
+    end
   end
 
   describe '#inverse' do


### PR DESCRIPTION
I've had this monkeypatched into Capybara for a while because it made some code cleaner.  Don't see any downside to having this directly in xpath.