### PR TITLE
support querying HTML5 attributes with "special" characters in them

### DIFF
--- a/lib/xpath/renderer.rb
+++ b/lib/xpath/renderer.rb
@@ -59,7 +59,11 @@ module XPath
     end
 
     def attribute(current, name)
-      "#{current}/@#{name}"
+      if valid_xml_name?(name)
+        "#{current}/@#{name}"
+      else
+        "#{current}/attribute::*[local-name(.) = #{string_literal(name)}]"
+      end
     end
 
     def binary_operator(name, left, right)
@@ -111,6 +115,10 @@ module XPath
       else
         "#{expression}*"
       end
+    end
+
+    def valid_xml_name?(name)
+      name =~ /^[a-zA-Z_:][a-zA-Z0-9_:\.\-]*$/
     end
   end
 end


### PR DESCRIPTION
The attribute names allowed by XML are very limited whereas HTML has opened them up to be pretty much anything.  That means `XPath::attr` can end up generating invalid XPath in some cases.  This PR creates a different xpath if the name passed to attr isn't a valid XML name.  Unfortunately testing this is difficult in the gem since Nokogiri discards the "invalid" attributes.  Chrome and FF don't discard them, and neither does Nokogumbo.

@jnicklas thoughts?