### PR TITLE
Revert required_ruby_version change for now, keep it 3.0+.

### DIFF
--- a/xpath.gemspec
+++ b/xpath.gemspec
@@ -7,7 +7,7 @@ require 'xpath/version'
 Gem::Specification.new do |s|
   s.name = 'xpath'
   s.version = XPath::VERSION
-  s.required_ruby_version = '>= 3.1'
+  s.required_ruby_version = '>= 3.0'
 
   s.authors = ['Jonas Nicklas']
   s.email = ['jonas.nicklas@gmail.com']


### PR DESCRIPTION
- for compatibility with Capybara current setup