### PR TITLE
Add Ruby 4.0 to CI test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4", "jruby"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "4.0", "jruby"]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Adds Ruby 4.0 to the rspec build matrix in `.github/workflows/build.yml`, so the gem is tested against the current stable Ruby release ([Ruby 4.0.0 shipped 2025-12-25](https://www.ruby-lang.org/en/news/)).

```diff
-        ruby: ["3.1", "3.2", "3.3", "3.4", "jruby"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "4.0", "jruby"]
```

## Validation

Ran the CI steps locally against Ruby 4.0.5:

```
$ ruby -v
ruby 4.0.5 (2026-05-20 revision 64336ffd0e) +PRISM [x86_64-linux]
$ bundle exec rake
74 examples, 0 failures
```

The full suite passes with no code changes required. Only the workflow matrix is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)